### PR TITLE
Эмуляция PDO, получение нативных типов данных из DB

### DIFF
--- a/system/src/Database/PdoFactory.php
+++ b/system/src/Database/PdoFactory.php
@@ -33,6 +33,7 @@ class PdoFactory
                     PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
                     PDO::MYSQL_ATTR_INIT_COMMAND => "SET NAMES 'utf8mb4'",
                     PDO::MYSQL_ATTR_USE_BUFFERED_QUERY,
+                    PDO::ATTR_EMULATE_PREPARES => false,
                 ]
             );
         } catch (\PDOException $e) {


### PR DESCRIPTION
Отключение эмуляции подготовленных запросов, на стороне PDO.
Для получения нативных типов данных. 